### PR TITLE
Add swift package manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 5.6
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "WherebySDK",
+    platforms: [
+        .iOS(.v14)
+    ],
+    products: [
+        .library(
+            name: "WherebySDK",
+            targets: ["WherebySDK", "mediasoup_client_ios", "WebRTC"])
+    ],
+    targets: [
+        .binaryTarget(name: "WherebySDK", path: "WherebySDK.xcframework"),
+        .binaryTarget(name: "mediasoup_client_ios", path: "mediasoup_client_ios.xcframework"),
+        .binaryTarget(name: "WebRTC", path: "WebRTC.xcframework")
+    ]
+)


### PR DESCRIPTION
This adds support for distribution via Swift Package Manager. 

Possible to try out with the separate demo app added in https://github.com/whereby/ios-sdk-demo/pull/4 The app in that PR points to this branch at the moment. Will have to be updated to use `main` once this is merged.

Will update the documentation separately.